### PR TITLE
Sandbox Contributions part 1

### DIFF
--- a/lang/README.md
+++ b/lang/README.md
@@ -59,12 +59,12 @@ in Pyret development, read on:
 
 The easiest way to *run* a Pyret program from the command-line is:
 
-    $ ./src/scripts/phaseX <path-to-pyret-program-here> [command-line-args...]
+    $ ./src/scripts/phaseX [-v] <path-to-pyret-program-here> [command-line-args...]
 
 Where `X` is `0`, `A`, `B`, or `C`, indicating a phase (described below). For
 example:
 
-    $ ./src/scripts/phaseA src/scripts/show-compilation.arr examples/ahoy-world.arr
+    $ ./src/scripts/phaseA -v src/scripts/show-compilation.arr examples/ahoy-world.arr
 
 Alternatively, you can compile and run a standalone JavaScript file via:
 

--- a/lang/src/arr/compiler/anf-loop-compiler.arr
+++ b/lang/src/arr/compiler/anf-loop-compiler.arr
@@ -801,9 +801,9 @@ end
 fun compile-anns(visitor, step, binds :: List<N.ABind>, entry-label):
   var cur-target = entry-label
   new-cases = for lists.fold(acc from cl-empty, b from binds):
-    if A.is-a-blank(b.ann) or A.is-a-any(b.ann) block:
+    if b.ann.is-ignorable() block:
       acc
-    else if A.is-a-tuple(b.ann) and b.ann.fields.all(lam(a): A.is-a-blank(a) or A.is-a-any(a) end):
+    else if A.is-a-tuple(b.ann) and b.ann.fields.all(lam(a): a.is-ignorable() end):
       new-label = visitor.make-label()
       new-case =
         j-case(cur-target,
@@ -861,7 +861,7 @@ fun compile-annotated-let(visitor, b :: BindType, compiled-e :: DAG.CaseResults%
       raise(string-append(string-append("Unknown ", b.value.label()), " in compile-annotated-let"))
     end
   shadow b = b.value
-  if A.is-a-blank(b.ann) or A.is-a-any(b.ann):
+  if b.ann.is-ignorable():
     c-block(
       j-block(
         cl-append(
@@ -872,7 +872,7 @@ fun compile-annotated-let(visitor, b :: BindType, compiled-e :: DAG.CaseResults%
         ),
       compiled-body.new-cases
       )
-  else if A.is-a-tuple(b.ann) and b.ann.fields.all(lam(a): A.is-a-blank(a) or A.is-a-any(a) end):
+  else if A.is-a-tuple(b.ann) and b.ann.fields.all(lam(a): a.is-ignorable() end):
     step = visitor.cur-step
     after-ann = visitor.make-label()
     after-ann-case = j-case(after-ann, j-block(compiled-body.block.stmts))
@@ -1833,7 +1833,7 @@ compiler-visitor = {
     fun make-variant-constructor(l2, base-id, brands-id, members, refl-name, refl-ref-fields-mask, refl-fields, constructor-id):
 
       nonblank-anns = for filter(m from members):
-        not(A.is-a-blank(m.bind.ann)) and not(A.is-a-any(m.bind.ann))
+        not(m.bind.ann.is-ignorable())
       end
       compiled-anns = for fold(acc from {anns: cl-empty, others: cl-empty}, m from nonblank-anns):
         compiled = compile-ann(m.bind.ann, none, self)

--- a/lang/src/arr/compiler/anf.arr
+++ b/lang/src/arr/compiler/anf.arr
@@ -202,13 +202,26 @@ fun anf(e :: A.Expr, k :: ANFCont) -> N.AExpr:
       end
 
     | s-letrec(l, binds, body, _) =>
-      let-binds = for map(b from binds):
-        A.s-var-bind(b.l, b.b, A.s-undefined(l))
+      undef-inits = for map(b from binds):
+        b-without-ann = A.s-bind(b.b.l, b.b.shadows, b.b.id, A.a-blank)
+        A.s-var-bind(b.l, b-without-ann, A.s-undefined(l))
       end
-      assigns = for map(b from binds):
-        A.s-assign(b.l, b.b.id, b.value)
-      end
-      anf(A.s-let-expr(l, let-binds, A.s-block(l, assigns + [list: body]), true), k)
+      { rev-tmp-binds; rev-assigns } = 
+        for fold({ tmp-binds-acc; assigns-acc } from { [list: ]; [list: ] }, b from binds):
+          if A.is-a-blank(b.b.ann) or A.is-a-any(b.b.ann):
+            new-assign = A.s-assign(b.l, b.b.id, b.value)
+            { tmp-binds-acc; link(new-assign, assigns-acc) }
+          else:
+            tmp-name-id = mk-id(b.l, "letrec_ann").id
+            b-with-tmp = A.s-bind(b.b.l, b.b.shadows, tmp-name-id, b.b.ann)
+            new-bind = A.s-let-bind(b.l, b-with-tmp, b.value)
+            new-assign = A.s-assign(b.l, b.b.id, A.s-id(b.l, tmp-name-id))
+            { link(new-bind, tmp-binds-acc); link(new-assign, assigns-acc) }
+          end
+        end
+      inner-let = A.s-let-expr(l, rev-tmp-binds.reverse(), 
+        A.s-block(l, rev-assigns.reverse() + [list: body]), true)
+      anf(A.s-let-expr(l, undef-inits, inner-let, false), k)
 
     | s-data-expr(l, data-name, data-name-t, params, mixins, variants, shared, _check-loc, _check) =>
       fun anf-member(member :: A.VariantMember):

--- a/lang/src/arr/compiler/anf.arr
+++ b/lang/src/arr/compiler/anf.arr
@@ -181,7 +181,7 @@ fun anf(e :: A.Expr, k :: ANFCont) -> N.AExpr:
         | link(f, r) =>
           cases(A.LetBind) f:
             | s-var-bind(l2, b, val) =>
-              if A.is-a-blank(b.ann) or A.is-a-any(b.ann):
+              if b.ann.is-ignorable():
                 anf-name(val, "var", lam(new-val):
                       N.a-var(l2, N.a-bind(l2, b.id, b.ann), N.a-val(new-val.l, new-val),
                         anf(A.s-let-expr(l, r, body, blocky), k))
@@ -312,7 +312,7 @@ fun anf(e :: A.Expr, k :: ANFCont) -> N.AExpr:
       anf(A.s-let-expr(l, bindings, A.s-id(l, name.id), false), k)
 
     | s-lam(l, name, params, args, ret, doc, body, _, _, _) =>
-      if A.is-a-blank(ret) or A.is-a-any(ret):
+      if ret.is-ignorable():
         k(N.a-lam(l, name, args.map(lam(a): N.a-bind(a.l, a.id, a.ann) end), ret, anf-term(body)))
       else:
         temp = mk-id(l, "ann_check_temp")
@@ -322,7 +322,7 @@ fun anf(e :: A.Expr, k :: ANFCont) -> N.AExpr:
                 A.s-id(l, temp.id), false))))
       end
     | s-method(l, name, params, args, ret, doc, body, _, _, _) =>
-      if A.is-a-blank(ret) or A.is-a-any(ret):
+      if ret.is-ignorable():
         k(N.a-method(l, name, args.map(lam(a): N.a-bind(a.l, a.id, a.ann) end), ret, anf-term(body)))
       else:
         temp = mk-id(l, "ann_check_temp")

--- a/lang/src/arr/compiler/resolve-scope.arr
+++ b/lang/src/arr/compiler/resolve-scope.arr
@@ -1328,19 +1328,26 @@ fun resolve-names(p :: A.Program, thismodule-uri :: String, initial-env :: C.Com
             cases(Option) maybe-uri block:
               | none => # path must be a single element if there's no URI of a remote module
                         # e.g. provide: D end   NOT    provide: M.D end
-                data-expr = datatypes.get-value-now(path.first.toname())
-                maybe-add(provided-datatypes, data-expr.name, {l; none; data-expr.namet})
-                data-checker-name = A.make-checker-name(data-expr.name)
-                data-checker-vb = val-env.get-value(data-checker-name)
-                maybe-add(provided-values, data-checker-name, {l; none; data-checker-vb.atom})
-                data-alias-tb = type-env.get-value(data-expr.name)
-                maybe-add(provided-types, data-expr.name, {l; none; data-alias-tb.atom})
-                for each(v from data-expr.variants) block:
-                  variant-vb = val-env.get-value(v.name)
-                  checker-name = A.make-checker-name(v.name)
-                  variant-checker-vb = val-env.get-value(checker-name)
-                  maybe-add(provided-values, v.name, {l; none; variant-vb.atom})
-                  maybe-add(provided-values, checker-name, {l; none; variant-checker-vb.atom})
+
+                data-expr = datatypes.get-now(path.first.toname())
+                cases(Option) data-expr block:
+                  | some(shadow data-expr) =>
+                    maybe-add(provided-datatypes, data-expr.name, {l; none; data-expr.namet})
+                    data-checker-name = A.make-checker-name(data-expr.name)
+                    data-checker-vb = val-env.get-value(data-checker-name)
+                    maybe-add(provided-values, data-checker-name, {l; none; data-checker-vb.atom})
+                    data-alias-tb = type-env.get-value(data-expr.name)
+                    maybe-add(provided-types, data-expr.name, {l; none; data-alias-tb.atom})
+                    for each(v from data-expr.variants) block:
+                      variant-vb = val-env.get-value(v.name)
+                      checker-name = A.make-checker-name(v.name)
+                      variant-checker-vb = val-env.get-value(checker-name)
+                      maybe-add(provided-values, v.name, {l; none; variant-vb.atom})
+                      maybe-add(provided-values, checker-name, {l; none; variant-checker-vb.atom})
+                    end
+                  | none =>
+                    name-errors := link(C.unbound-id(A.s-id(l, A.s-name(l, path.last().toname()))), name-errors)
+                    { none; A.s-name(l, path.last().toname()) }
                 end
                 
               | some(uri) =>

--- a/lang/src/arr/trove/ast.arr
+++ b/lang/src/arr/trove/ast.arr
@@ -1781,9 +1781,11 @@ data Ann:
   | a-blank with:
     method label(self): "a-blank" end,
     method tosource(self): str-any end,
+    method is-ignorable(self): true end,
   | a-any(l :: Loc) with:
     method label(self): "a-any" end,
     method tosource(self): str-any end,
+    method is-ignorable(self): true end,
   | a-name(l :: Loc, id :: Name) with:
     method label(self): "a-name" end,
     method tosource(self): self.id.tosource() end,
@@ -1848,10 +1850,13 @@ data Ann:
     method tosource(self): self.obj.tosource() + PP.str("." + self.field) end,
   | a-checked(checked :: Ann, residual :: Ann) with:
     method label(self): "a-checked" end,
-    method tosource(self): self.residual.tosource() end
+    method tosource(self): self.residual.tosource() end,
 sharing:
   method visit(self, visitor):
     self._match(visitor, lam(val): raise("No visitor field for " + self.label()) end)
+  end,
+  method is-ignorable(self):
+    false
   end
 end
 

--- a/lang/src/arr/trove/error.arr
+++ b/lang/src/arr/trove/error.arr
@@ -2302,8 +2302,12 @@ data RuntimeError:
               else if src-available(loc):
                 cases(O.Option) maybe-ast(loc):
                   | some(ast) =>
-                    left-loc =  ast.left.l
-                    right-loc = ast.right.l
+                    {left-loc; right-loc} = cases(Any) ast:
+                      | s-op(_, _, _, left-expr, right-expr) =>
+                        {left-expr.l; right-expr.l}
+                      | s-app(_, _, args) =>
+                        {args.get(0).l; args.get(1).l}
+                    end
                     [ED.sequence:
                       ed-intro("equality comparison", loc, -1, true),
                       ED.cmcode(loc),

--- a/lang/src/arr/trove/error.arr
+++ b/lang/src/arr/trove/error.arr
@@ -718,18 +718,29 @@ data RuntimeError:
       else if src-available(self.loc):
         cases(O.Option) maybe-ast(self.loc):
           | some(ast) =>
-            shadow ast = cases(Any) ast:
-              | s-dot(_,_,_) => ast
-              | s-app(_,f,_) => f
+            if self.field == "load":
+              # load-table ... source: "..." end desugars to "...".load(...),
+              # so self.field is "load" and the pre-desugar AST is s-load-table.
+              [ED.error:
+                ed-intro("table loader expression", self.loc, -1, true),
+                ED.cmcode(self.loc),
+                [ED.para:
+                  ED.text("The source could not be loaded:")],
+                ED.embed(self.non-obj)]
+            else:
+              shadow ast = cases(Any) ast:
+                | s-dot(_,_,_) => ast
+                | s-app(_,f,_) => f
+              end
+              [ED.error:
+                ed-intro("field lookup expression", self.loc, -1, true),
+                ED.cmcode(self.loc),
+                [ED.para:
+                  ED.text("The "),
+                  ED.highlight(ED.text("left side"), [ED.locs: ast.obj.l], 0),
+                  ED.text(" was not an object:")],
+                ED.embed(self.non-obj)]
             end
-            [ED.error:
-              ed-intro("field lookup expression", self.loc, -1, true),
-              ED.cmcode(self.loc),
-              [ED.para:
-                ED.text("The "),
-                ED.highlight(ED.text("left side"), [ED.locs: ast.obj.l], 0),
-                ED.text(" was not an object:")],
-              ED.embed(self.non-obj)]
           | none =>
             [ED.error:
               ed-intro("field lookup expression", self.loc, -1, true),

--- a/lang/src/scripts/run-phase
+++ b/lang/src/scripts/run-phase
@@ -15,6 +15,16 @@ then
     exit 1
 fi
 
+VERBOSE=0
+if [ "$#" -gt 0 ] && [ "$1" = "-v" ]; then
+    VERBOSE=1
+    shift 1
+fi
+if [ "$#" -lt 1 ]; then
+  echo "Expecting 1 argument; received $#"
+  echo "Usage: $PHASE [-v] file.arr [args]"
+  exit 1
+fi
 PHASE="$SYMLINK_NAME"
 PYRET_JARR="build/$PHASE/pyret.jarr"
 FILE=$1
@@ -40,9 +50,16 @@ fi
 
 shift 1
 
+if [ "$VERBOSE" = 1 ]
+then
+    PROGRESS_FLAG=""
+else
+    PROGRESS_FLAG="-no-display-progress"
+fi
+
 if [ "$#" -gt 0 ]
 then
-    $NODE $PYRET_JARR -no-display-progress --run $FILE - "$@"
+    $NODE $PYRET_JARR $PROGRESS_FLAG --run $FILE - "$@"
 else
-    $NODE $PYRET_JARR -no-display-progress --run $FILE
+    $NODE $PYRET_JARR $PROGRESS_FLAG --run $FILE
 fi

--- a/lang/src/scripts/show-compilation.arr
+++ b/lang/src/scripts/show-compilation.arr
@@ -6,6 +6,7 @@ import parse-pyret as P
 import string-dict as SD
 import pprint as PP
 import pathlib as PL
+import render-error-display as RED
 import file("../../src/arr/compiler/desugar.arr") as D
 import file("../../src/arr/compiler/desugar-check.arr") as DC
 import ast as A
@@ -128,7 +129,18 @@ cases (C.ParsedArguments) parsed-options block:
         comp = cases(E.Either) compiled block:
           | left(v) =>
             println("Compilation failed")
-            {_; traces} = v
+            {loadables; traces} = v
+            errors = loadables
+              .filter(CL.is-error-compilation)
+              .map(_.result-printer)
+              .map(_.problems)
+              .foldr(_ + _, empty)
+
+            for each(err from errors) block:
+              println(to-repr(err))
+              println(RED.display-to-string(err.render-reason(), torepr, empty))
+            end
+
             traces.get-value-now(PL.basename(file, ""))
           | right(v) =>
             {_; traces} = v

--- a/lang/tests/pyret/regression/letrec-ann.arr
+++ b/lang/tests/pyret/regression/letrec-ann.arr
@@ -1,0 +1,7 @@
+check "https://github.com/brownplt/pyret-lang/issues/1700":
+  letrec n :: Number%(is-zero) = 10, is-zero = lam(x): x == 0 end: n end
+    raises "uninitialized-id"
+ 
+  letrec is-zero = lam(x): x == 0, n :: Number%(is-zero) = 10 end: n end
+    raises "type-mismatch"
+end

--- a/lang/tests/pyret/tests/test-modules.arr
+++ b/lang/tests/pyret/tests/test-modules.arr
@@ -481,3 +481,33 @@ end
   errs is%(error-with) "j"
 end
 
+check "https://github.com/brownplt/pyret-lang/issues/1790": 
+  m = make-fresh-module-testing-context() 
+  m.save-module("main.arr", ```
+provide:
+  data Foo
+end
+
+type Foo = {}
+```)
+  
+  errs = m.compile-error-messages("main.arr")
+  errs is%(error-with) "Foo"
+end
+
+check "https://github.com/brownplt/pyret-lang/issues/1790": 
+  m = make-fresh-module-testing-context() 
+  m.save-module("main.arr", ```
+provide:
+  data Foo
+end
+
+data Bar:
+  | variant
+end
+```)
+  
+  errs = m.compile-error-messages("main.arr")
+  errs is%(error-with) "Foo"
+end
+

--- a/vscode/.gitignore
+++ b/vscode/.gitignore
@@ -3,3 +3,4 @@
 out
 dist
 node_modules
+build

--- a/vscode/media/icons/jarr.svg
+++ b/vscode/media/icons/jarr.svg
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+<svg xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" width="32" height="32" id="svg2" version="1.1" inkscape:version="0.48.3.1 r9886" sodipodi:docname="pyret-icon.svg" inkscape:export-filename="/home/joe/src/pyret-lang/img/pyret-icon.png" inkscape:export-xdpi="90" inkscape:export-ydpi="90">
+  <defs id="defs4"/>
+  <sodipodi:namedview id="base" pagecolor="#ffffff" bordercolor="#666666" borderopacity="1.0" inkscape:pageopacity="0.0" inkscape:pageshadow="2" inkscape:zoom="15.839192" inkscape:cx="3.488409" inkscape:cy="15.160383" inkscape:document-units="px" inkscape:current-layer="layer1-5" showgrid="false" inkscape:window-width="1280" inkscape:window-height="775" inkscape:window-x="0" inkscape:window-y="0" inkscape:window-maximized="1"/>
+  <metadata id="metadata7">
+    <rdf:RDF>
+      <cc:Work rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+        <dc:title/>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g inkscape:label="Layer 1" inkscape:groupmode="layer" id="layer1" transform="translate(0,-1020.3622)">
+    <g transform="translate(-962.67857,631.60716)" id="layer1-5" inkscape:label="Layer 1">
+      <g id="g3442" transform="matrix(0.06075681,0,0,0.06075681,955.78354,375.41944)">
+        <path id="path3107-06-2-5" d="m 221.91592,348.09274 c 44.806,32.322 266.82803,285.788 276.42103,319.032 9.593,33.242 -0.866,49.114 28.375,53.248 35.173,4.973 36.099,-31.896 36.099,-31.896 0,0 63.539,-6.842 57.539,-33.842 -25,-45 -41.632,-13.512 -70,-14 -28.368,-0.488 -292.87703,-320.54302 -297.23203,-341.00002 -3.947,-18.542 -14.115,-51.116 -39.957,-46.78 -32.672,5.482 -13.811,43.78 -13.811,43.78 0,0 -70,-20 -58.908,33.931 8.658,42.10102 57.692,0.371 81.474,17.52702 z" inkscape:connector-curvature="0" style="fill:#fafafa;stroke:#212121;stroke-width:20"/>
+        <path id="path3109-9-4-8" d="m 240.87792,675.28274 c 19.505,-46.82 18.228,-45.057 107.78403,-156.783 l -37.765,-26.979 c 0,0 -86.47903,136.914 -103.72203,145.029 -15.629,7.357 -42.466,5.293 -47.843,18.99 -11.025,28.1 33.316,37.609 33.316,37.609 0,0 -1.874,27.332 20.534,25.318 39.009,-3.508 17.42,-18.518 27.696,-43.184 z" inkscape:connector-curvature="0" style="fill:#fafafa;stroke:#212121;stroke-width:20"/>
+        <path id="path3111-7-0-2" d="m 400.72885,418.11398 c 23.7366,16.05765 82.888,33.91083 82.888,33.91083" inkscape:connector-curvature="0" style="fill:none;stroke:#212121;stroke-width:6.07416105"/>
+        <path style="fill:#616161;fill-opacity:1;stroke:#212121;stroke-width:20;stroke-miterlimit:4;stroke-dasharray:none" id="path3117-5-0-3" inkscape:connector-curvature="0" sodipodi:nodetypes="cccccccc" d="m 454.46495,527.63469 c 3.8425,-26.04965 41.6634,-24.72663 41.3682,-65.51584 -0.1409,-19.5588 -1.3071,-119.34147 -131.593,-120.05337 l 0.9232,0 c -130.28469,0.7119 -130.02836,100.55774 -131.59307,120.05337 -3.61534,45.03383 40.60267,42.03301 45.81737,65.33712 12.8562,61.80476 22.2917,115.8024 91.023,117.27086 66.7954,0.45766 73.0667,-55.45666 84.0543,-117.09214 z"/>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/vscode/media/icons/pyret.svg
+++ b/vscode/media/icons/pyret.svg
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="32"
+   height="32"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.3.1 r9886"
+   sodipodi:docname="pyret-icon.svg"
+   inkscape:export-filename="/home/joe/src/pyret-lang/img/pyret-icon.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="15.839192"
+     inkscape:cx="3.488409"
+     inkscape:cy="15.160383"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1-5"
+     showgrid="false"
+     inkscape:window-width="1280"
+     inkscape:window-height="775"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1" />
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-1020.3622)">
+    <g
+       transform="translate(-962.67857,631.60716)"
+       id="layer1-5"
+       inkscape:label="Layer 1">
+      <g
+         id="g3442"
+         transform="matrix(0.06075681,0,0,0.06075681,955.78354,375.41944)">
+        <path
+           id="path3107-06-2-5"
+           d="m 221.91592,348.09274 c 44.806,32.322 266.82803,285.788 276.42103,319.032 9.593,33.242 -0.866,49.114 28.375,53.248 35.173,4.973 36.099,-31.896 36.099,-31.896 0,0 63.539,-6.842 57.539,-33.842 -25,-45 -41.632,-13.512 -70,-14 -28.368,-0.488 -292.87703,-320.54302 -297.23203,-341.00002 -3.947,-18.542 -14.115,-51.116 -39.957,-46.78 -32.672,5.482 -13.811,43.78 -13.811,43.78 0,0 -70,-20 -58.908,33.931 8.658,42.10102 57.692,0.371 81.474,17.52702 z"
+           inkscape:connector-curvature="0"
+           style="fill:#fafafa;stroke:#212121;stroke-width:20" />
+        <path
+           id="path3109-9-4-8"
+           d="m 240.87792,675.28274 c 19.505,-46.82 18.228,-45.057 107.78403,-156.783 l -37.765,-26.979 c 0,0 -86.47903,136.914 -103.72203,145.029 -15.629,7.357 -42.466,5.293 -47.843,18.99 -11.025,28.1 33.316,37.609 33.316,37.609 0,0 -1.874,27.332 20.534,25.318 39.009,-3.508 17.42,-18.518 27.696,-43.184 z"
+           inkscape:connector-curvature="0"
+           style="fill:#fafafa;stroke:#212121;stroke-width:20" />
+        <path
+           id="path3111-7-0-2"
+           d="m 400.72885,418.11398 c 23.7366,16.05765 82.888,33.91083 82.888,33.91083"
+           inkscape:connector-curvature="0"
+           style="fill:none;stroke:#212121;stroke-width:6.07416105" />
+        <path
+           id="path3115-3-8-3"
+           d="M 303.14245,513.17946"
+           inkscape:connector-curvature="0"
+           style="fill:#f44336;stroke:#212121;stroke-width:24.29664421" />
+        <path
+           style="fill:#dd2c00;fill-opacity:1;stroke:#212121;stroke-width:20;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path3117-5-0-3"
+           d="m 454.46495,527.63469 c 3.8425,-26.04965 41.6634,-24.72663 41.3682,-65.51584 -0.1409,-19.5588 -1.3071,-119.34147 -131.593,-120.05337 l 0.9232,0 c -130.28469,0.7119 -130.02836,100.55774 -131.59307,120.05337 -3.61534,45.03383 40.60267,42.03301 45.81737,65.33712 12.8562,61.80476 22.2917,115.8024 91.023,117.27086 66.7954,0.45766 73.0667,-55.45666 84.0543,-117.09214 z"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cccccccc" />
+        <path
+           sodipodi:nodetypes="ccccscc"
+           style="fill:#304ffe;fill-opacity:1;stroke:#212121;stroke-width:20;stroke-miterlimit:4;stroke-dasharray:none"
+           inkscape:connector-curvature="0"
+           id="path3121-79-8-5"
+           d="m 494.20735,460.52751 c -0.9059,34.12909 -35.1332,47.52683 -35.1332,47.52683 -5.6308,4.79793 -35.2939,-10.58752 -62.8426,-29.22304 -35.0346,-23.70016 -95.6633,-120.5563 -95.6633,-120.5563 0,0 -2.2023,-14.38181 64.7325,-16.3377 66.9324,-1.95588 101.9563,41.60643 107.1193,50.11876 5.1655,8.51354 18.5137,28.77817 21.7873,68.47145 z" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -33,7 +33,24 @@
 				"extensions": [
 					".arr"
 				],
+				"icon": {
+					"light": "./media/icons/pyret.svg",
+					"dark": "./media/icons/pyret.svg"
+				},
 				"configuration": "./language-configuration.json"
+			},
+			{
+				"id": "jarr",
+				"aliases": [
+					"jarr"
+				],
+				"extensions": [
+					".jarr"
+				],
+				"icon": {
+					"light": "./media/icons/jarr.svg",
+					"dark": "./media/icons/jarr.svg"
+				}
 			}
 		],
 		"grammars": [


### PR DESCRIPTION
These are the non-lsp and non-doc related changes that were made by our sandbox team during the spring semester.

They correspond to the following PRs on our fork:
- https://github.com/sandboxnu/pyret-lang/pull/11
- https://github.com/sandboxnu/pyret-lang/pull/12
- https://github.com/sandboxnu/pyret/pull/26
- https://github.com/sandboxnu/pyret/pull/32
- https://github.com/sandboxnu/pyret/pull/37
- https://github.com/sandboxnu/pyret/pull/39
- https://github.com/sandboxnu/pyret/pull/36

----

Fixes: https://github.com/brownplt/pyret-lang/issues/1790, https://github.com/brownplt/pyret-lang/issues/1700, https://github.com/brownplt/pyret-lang/issues/1845, https://github.com/brownplt/pyret-lang/issues/1855

Adds file icons to the VSCode extension and refactors `Ann::is-ignorable` in preparation for our LSP changes.

---

Once these are reviewed, we should probably go through the LSP on a call, before opening a PR.

---

cc: @zackbach, @jiang-h-y